### PR TITLE
Test adding outstanding laravel 5.x version using PHP 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,10 @@ matrix:
       env: ILLUMINATE_VERSION=5.5.*
     - php: 7.3
       env: ILLUMINATE_VERSION=5.6.*
+    - php: 7.3
+      env: ILLUMINATE_VERSION=5.7.*
+    - php: 7.3
+      env: ILLUMINATE_VERSION=5.8.*
 
 # instal our framework version
 before_install:
@@ -39,7 +43,7 @@ before_install:
 
 # install dependencies and build
 install:
-  - composer update --prefer-source --no-interaction
+  - COMPOSER_MEMORY_LIMIT=-1 travis_retry composer update --prefer-source --no-interaction
 
 script:
    - composer test

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,9 @@ matrix:
       env: ILLUMINATE_VERSION=5.4.*
     - php: 7.1
       env: ILLUMINATE_VERSION=5.5.*
-      
+    - php: 7.3
+      env: ILLUMINATE_VERSION=5.6.*
+
 # instal our framework version
 before_install:
   - composer require "laravel/framework:${ILLUMINATE_VERSION}" --no-update
@@ -36,7 +38,7 @@ before_install:
   # composer create-project laravel/laravel
 
 # install dependencies and build
-install: 
+install:
   - composer update --prefer-source --no-interaction
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ matrix:
 before_install:
   - composer require "laravel/framework:${ILLUMINATE_VERSION}" --no-update
   - composer require "laravel/laravel:${ILLUMINATE_VERSION}" --no-update
+  - composer require mockery/mockery --dev
   # composer create-project laravel/laravel
 
 # install dependencies and build

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,6 @@ matrix:
     - php: 7.3
       env: ILLUMINATE_VERSION=5.6.*
     - php: 7.3
-      env: ILLUMINATE_VERSION=5.7.*
-    - php: 7.3
-      env: ILLUMINATE_VERSION=5.8.*
 
 # instal our framework version
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,10 @@ cache:
 
 matrix:
   include:
-    - php: 5.6
-      env: ILLUMINATE_VERSION=5.3.*
-    - php: 5.6
-      env: ILLUMINATE_VERSION=5.4.*
+    # - php: 5.6
+    #   env: ILLUMINATE_VERSION=5.3.*
+    # - php: 5.6
+    #   env: ILLUMINATE_VERSION=5.4.*
     - php: 7.0
       env: ILLUMINATE_VERSION=5.3.*
     - php: 7.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ matrix:
       env: ILLUMINATE_VERSION=5.5.*
     - php: 7.3
       env: ILLUMINATE_VERSION=5.6.*
-    - php: 7.3
 
 # instal our framework version
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,8 @@ matrix:
 before_install:
   - composer require "laravel/framework:${ILLUMINATE_VERSION}" --no-update
   - composer require "laravel/laravel:${ILLUMINATE_VERSION}" --no-update
-  - composer require mockery/mockery --dev
-  # composer create-project laravel/laravel
+  # - composer require mockery/mockery --dev # only required for >= 5.7
+  # - composer create-project laravel/laravel
 
 # install dependencies and build
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ before_install:
 
 # install dependencies and build
 install:
-  - COMPOSER_MEMORY_LIMIT=-1 travis_retry composer update --prefer-source --no-interaction
+  - COMPOSER_MEMORY_LIMIT=-1 travis_retry composer update --prefer-source --no-interaction --dev
 
 script:
    - composer test


### PR DESCRIPTION
# Testing adding laravel version to CI

We want see if our current setup works with the remaining version of Laravel 5.x

- [x] Remove PHP 5.6 from CI
- [x] Fix composer memory limits in CI
- [x] Add laravel 5.6
- [ ] ~~Add laravel 5.7~~
- [ ] ~~Add laravel 5.8~~
